### PR TITLE
Dokarkiv returnerer journalpostid ved 409 conflict

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/DokarkivController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/DokarkivController.kt
@@ -2,6 +2,7 @@ package no.nav.tilleggsstonader.integrasjoner.dokarkiv
 
 import jakarta.validation.Valid
 import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.tilleggsstonader.integrasjoner.dokarkiv.client.DokarkivConflictException
 import no.nav.tilleggsstonader.integrasjoner.dokarkiv.client.KanIkkeFerdigstilleJournalpostException
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.ArkiverDokumentRequest
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.ArkiverDokumentResponse
@@ -58,6 +59,11 @@ class DokarkivController(private val journalføringService: DokarkivService) {
     fun handleKanIkkeFerdigstilleException(ex: KanIkkeFerdigstilleJournalpostException): ProblemDetail {
         LOG.warn("Feil ved ferdigstilling {}", ex.message)
         return ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, ex.message ?: "Uventer feil")
+    }
+
+    @ExceptionHandler(DokarkivConflictException::class)
+    fun handleDokarkivConflictException(ex: DokarkivConflictException): ResponseEntity<ArkiverDokumentResponse> {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(ex.response)
     }
 
     @PostMapping

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/client/DokarkivException.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/client/DokarkivException.kt
@@ -1,0 +1,7 @@
+package no.nav.tilleggsstonader.integrasjoner.dokarkiv.client
+
+import no.nav.tilleggsstonader.kontrakter.dokarkiv.ArkiverDokumentResponse
+
+class KanIkkeFerdigstilleJournalpostException(message: String?) : RuntimeException(message)
+
+class DokarkivConflictException(val response: ArkiverDokumentResponse) : RuntimeException()

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/client/DokarkivRestClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/client/DokarkivRestClient.kt
@@ -44,14 +44,14 @@ class DokarkivRestClient(
         try {
             return postForEntity(uri, request, headers(navIdent), mapOf("ferdigstill" to ferdigstill))
         } catch (e: RuntimeException) {
-            if (e is HttpClientErrorException && e.statusCode == HttpStatus.CONFLICT) {
+            if (e is HttpClientErrorException.Conflict) {
                 håndterConflict(e)
             }
             throw oppslagExceptionVed("opprettelse", e, request.bruker?.id)
         }
     }
 
-    private fun håndterConflict(e: HttpClientErrorException) {
+    private fun håndterConflict(e: HttpClientErrorException.Conflict) {
         var response: ArkiverDokumentResponse? = null
         try {
             response = objectMapper.readValue<ArkiverDokumentResponse>(e.responseBodyAsString)
@@ -62,7 +62,7 @@ class DokarkivRestClient(
                 OppslagException.Level.KRITISK,
                 HttpStatus.INTERNAL_SERVER_ERROR,
                 e,
-                sensitiveInfo = "Body=${e.responseBodyAsString}"
+                sensitiveInfo = "Body=${e.responseBodyAsString}",
             )
         }
         throw DokarkivConflictException(response)
@@ -115,7 +115,7 @@ class DokarkivRestClient(
             if (e.statusCode == HttpStatus.BAD_REQUEST) {
                 throw KanIkkeFerdigstilleJournalpostException(
                     "Kan ikke ferdigstille journalpost " +
-                            "$journalpostId body ${e.responseBodyAsString}",
+                        "$journalpostId body ${e.responseBodyAsString}",
                 )
             }
             throw e

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/client/DokarkivRestClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/client/DokarkivRestClient.kt
@@ -57,7 +57,7 @@ class DokarkivRestClient(
             response = objectMapper.readValue<ArkiverDokumentResponse>(e.responseBodyAsString)
         } catch (ex: Exception) {
             throw OppslagException(
-                "Klarer ikke å parsea response fra dokarkiv ved 409",
+                "Klarer ikke å parse response fra dokarkiv ved 409",
                 "Dokarkiv",
                 OppslagException.Level.KRITISK,
                 HttpStatus.INTERNAL_SERVER_ERROR,

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/client/KanIkkeFerdigstilleJournalpostException.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/client/KanIkkeFerdigstilleJournalpostException.kt
@@ -1,3 +1,0 @@
-package no.nav.tilleggsstonader.integrasjoner.dokarkiv.client
-
-class KanIkkeFerdigstilleJournalpostException(message: String?) : RuntimeException(message)

--- a/src/test/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/DokarkivControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/DokarkivControllerTest.kt
@@ -175,7 +175,7 @@ class DokarkivControllerTest : IntegrationTest() {
         }
 
         assertThat(response.httpStatus).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
-        assertThat(response.detail.detail).isEqualTo("[Dokarkiv][Klarer ikke å parsea response fra dokarkiv ved 409][org.springframework.web.client.HttpClientErrorException\$Conflict]")
+        assertThat(response.detail.detail).isEqualTo("[Dokarkiv][Klarer ikke å parse response fra dokarkiv ved 409][org.springframework.web.client.HttpClientErrorException\$Conflict]")
     }
 
     @Test


### PR DESCRIPTION
I ef-mottak catcher man exception, så kaller man journalpost-api for å søke etter journalpostId, men de returneres i svaret ved 409l, så tenker vi kan sende videre den