### PR TITLE
✨  Skal kunne bruke client-credential auth mot saf ved henting av dokumenter

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/journalpost/client/SafHentDokumentClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/journalpost/client/SafHentDokumentClient.kt
@@ -22,7 +22,7 @@ import java.net.URI
 @Service
 class SafHentDokumentClient(
     @Value("\${clients.saf.uri}") safBaseUrl: URI,
-    @Qualifier("azureOnBehalfOf") restTemplate: RestTemplate,
+    @Qualifier("azure") restTemplate: RestTemplate,
 ) : AbstractRestClient(restTemplate) {
 
     private val safHentdokumentUri = UriComponentsBuilder.fromUri(safBaseUrl).path(PATH_HENT_DOKUMENT)


### PR DESCRIPTION
**Hvorfor?**
Når vi automatisk journalfører må vi kunne hente søknaden for å lagre den i databasen. Må derfor kunne bruke client credential auth ved henting av dokumenter.