### PR TITLE
🐛  Oppgaver skal kun kunne tilordnes på gyldige nav-identer

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/oppgave/OppgaveService.kt
@@ -125,7 +125,7 @@ class OppgaveService(
             oppgavetype = request.oppgavetype.value,
             beskrivelse = request.beskrivelse,
             behandlingstype = request.behandlingstype,
-            tilordnetRessurs = request.tilordnetRessurs?.let { hentNavIdent(it) },
+            tilordnetRessurs = request.tilordnetRessurs?.let { validerNavIdent(it) },
             behandlesAvApplikasjon = request.behandlesAvApplikasjon,
             mappeId = request.mappeId,
         )
@@ -133,10 +133,13 @@ class OppgaveService(
         return oppgaveClient.opprettOppgave(oppgave)
     }
 
-    private fun hentNavIdent(id: String): String {
-        if (id.length != 7 && id != SikkerhetsContext.SYSTEM_FORKORTELSE) {
+    private fun validerNavIdent(id: String): String {
+        val lengdeNavIdent = 7
+
+        if (id.length == lengdeNavIdent) {
             return id
         }
+
         error("Ident=$id er ugyldig")
     }
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Var en task som feilet på opprettelse av behandleSak oppgave: https://tilleggsstonader-prosessering.intern.dev.nav.no/service/tilleggsstonader-sak/gruppert?statusFilter=FEILET&callId=712ec557-a76c-47fe-8cac-4b7a3eefd207

Vi hadde visst feil fortegn på if-sjekken validerte navIdent.


