### PR TITLE
🐛 Bruk saf-scope mot dokdist

### DIFF
--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -9,7 +9,7 @@ clients:
     scope: api://${CLIENT_ENV}-fss.teamdokumenthandtering.dokarkiv-q1/.default
   dokdist:
     uri: https://dokdistfordeling-q1.dev-fss-pub.nais.io
-    scope: api://${CLIENT_ENV}-fss.teamdokumenthandtering.dokdistfordeling-q1/.default
+    scope: api://${CLIENT_ENV}-fss.teamdokumenthandtering.saf-q1/.default
   saf:
     # saf-q1.dev er på saf.dev
     uri: https://saf.dev-fss-pub.nais.io

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -114,7 +114,7 @@ clients:
     scope: api://${CLIENT_ENV}-fss.teamdokumenthandtering.dokarkiv/.default
   dokdist:
     uri: https://dokdistfordeling.prod-fss-pub.nais.io
-    scope: api://${CLIENT_ENV}-fss.teamdokumenthandtering.dokdistfordeling/.default
+    scope: api://${CLIENT_ENV}-fss.teamdokumenthandtering.saf/.default
   saf:
     uri: https://saf.prod-fss-pub.nais.io
     scope: api://${CLIENT_ENV}-fss.teamdokumenthandtering.saf/.default


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ref [dokumentasjonen til dokdist](https://confluence.adeo.no/display/BOA/Distribuere+dokument+til+bruker#Distribueredokumenttilbruker-KomigangmeddistribusjonavdokumentermeddistribuerJournalpost) skal man bruke saf-scope.