### PR TITLE
Skal fordele oppgave til saksbehandler

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/oppgave/OppgaveService.kt
@@ -63,7 +63,7 @@ class OppgaveService(
         val oppdatertOppgaveDto = oppgave.copy(
             id = oppgave.id,
             versjon = versjon ?: oppgave.versjon,
-            tilordnetRessurs = "",
+            tilordnetRessurs = saksbehandler ?: "",
             beskrivelse = lagOppgaveBeskrivelseFordeling(oppgave = oppgave, nySaksbehandlerIdent = saksbehandler),
         )
         return oppgaveClient.oppdaterOppgave(oppdatertOppgaveDto)


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Når jeg testet sett på vent fant jeg denne, men såg nå også at det var rapportert 

Årsaken til dette er nog pga at vi tok å forenklet versjonen fra familie-integrasjoner der det er 2 helt ulike metoder. Vi har slått sammen de, men satte aldrig riktig `tilordnetRessurs`

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-18732