### PR TITLE
✨ Skal kunne oppdatere logiske vedlegg på journalpost/dokument

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 val javaVersion = JavaLanguageVersion.of(21)
 val springdocVersion = "2.4.0"
-val tilleggsstønaderLibsVersion = "2024.03.11-08.21.f30618621f1d"
-val tilleggsstønaderKontrakterVersion = "2024.03.25-13.16.c4f871d62dc4"
+val tilleggsstønaderLibsVersion = "2024.04.15-16.05.512a4905d78d"
+val tilleggsstønaderKontrakterVersion = "2024.04.15-14.00.c37cd4f5e87d"
 val tokenSupportVersion = "4.1.4"
 val springCloudVersion = "4.1.2"
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/DokarkivController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/DokarkivController.kt
@@ -6,6 +6,7 @@ import no.nav.tilleggsstonader.integrasjoner.dokarkiv.client.DokarkivConflictExc
 import no.nav.tilleggsstonader.integrasjoner.dokarkiv.client.KanIkkeFerdigstilleJournalpostException
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.ArkiverDokumentRequest
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.ArkiverDokumentResponse
+import no.nav.tilleggsstonader.kontrakter.dokarkiv.BulkOppdaterLogiskVedleggRequest
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.LogiskVedleggRequest
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.LogiskVedleggResponse
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.OppdaterJournalpostRequest
@@ -114,6 +115,16 @@ class DokarkivController(private val journalføringService: DokarkivService) {
     ): LogiskVedleggResponse {
         journalføringService.slettLogiskVedlegg(dokumentinfoId, logiskVedleggId)
         return LogiskVedleggResponse(logiskVedleggId.toLong())
+    }
+
+    @PutMapping(path = ["/dokument/{dokumentinfoId}/logiskVedlegg"], produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun oppdaterAlleLogiskeVedleggForDokument(
+        @PathVariable(name = "dokumentinfoId") dokumentinfoId: String,
+        @RequestBody @Valid
+        request: BulkOppdaterLogiskVedleggRequest,
+    ): ResponseEntity<String> {
+        journalføringService.oppdaterLogiskeVedleggForDokument(dokumentinfoId, request)
+        return ResponseEntity.status(HttpStatus.OK).body(dokumentinfoId)
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/DokarkivService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/DokarkivService.kt
@@ -10,6 +10,7 @@ import no.nav.tilleggsstonader.integrasjoner.dokarkiv.metadata.tilMetadata
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.ArkiverDokumentRequest
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.ArkiverDokumentResponse
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.AvsenderMottaker
+import no.nav.tilleggsstonader.kontrakter.dokarkiv.BulkOppdaterLogiskVedleggRequest
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.DokarkivBruker
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.Dokument
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.Filtype
@@ -143,5 +144,12 @@ class DokarkivService(
 
     fun slettLogiskVedlegg(dokumentInfoId: String, logiskVedleggId: String) {
         dokarkivLogiskVedleggRestClient.slettLogiskVedlegg(dokumentInfoId, logiskVedleggId)
+    }
+
+    fun oppdaterLogiskeVedleggForDokument(
+        dokumentinfoId: String,
+        request: BulkOppdaterLogiskVedleggRequest,
+    ) {
+        dokarkivLogiskVedleggRestClient.oppdaterLogiskeVedlegg(dokumentinfoId, request)
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/client/DokarkivLogiskVedleggRestClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/client/DokarkivLogiskVedleggRestClient.kt
@@ -2,6 +2,7 @@ package no.nav.tilleggsstonader.integrasjoner.dokarkiv.client
 
 import no.nav.tilleggsstonader.integrasjoner.infrastruktur.exception.OppslagException
 import no.nav.tilleggsstonader.integrasjoner.util.MDCOperations
+import no.nav.tilleggsstonader.kontrakter.dokarkiv.BulkOppdaterLogiskVedleggRequest
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.LogiskVedleggRequest
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.LogiskVedleggResponse
 import no.nav.tilleggsstonader.libs.http.client.AbstractRestClient
@@ -58,6 +59,32 @@ class DokarkivLogiskVedleggRestClient(
             throw OppslagException(
                 message,
                 "Dokarkiv.logiskVedlegg.slett",
+                OppslagException.Level.MEDIUM,
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                e,
+            )
+        }
+    }
+
+    fun oppdaterLogiskeVedlegg(
+        dokumentinfoId: String,
+        request: BulkOppdaterLogiskVedleggRequest,
+    ) {
+        val uriVariables = mapOf("dokumentInfo" to dokumentinfoId)
+        val uri =
+            UriComponentsBuilder
+                .fromUri(dokarkivUrl)
+                .path(PATH_LOGISKVEDLEGG)
+                .buildAndExpand(dokumentinfoId)
+                .toUriString()
+        try {
+            putForEntityNullable<Unit>(uri, request, headers(), uriVariables)
+        } catch (e: RuntimeException) {
+            val responsebody = if (e is HttpStatusCodeException) e.responseBodyAsString else ""
+            val message = "Kan ikke bulk oppdatere logiske vedlegg for dokumentinfo $dokumentinfoId $responsebody"
+            throw OppslagException(
+                message,
+                "Dokarkiv.logiskVedlegg.oppdater",
                 OppslagException.Level.MEDIUM,
                 HttpStatus.INTERNAL_SERVER_ERROR,
                 e,

--- a/src/test/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/DokarkivControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/DokarkivControllerTest.kt
@@ -6,6 +6,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.anyUrl
 import com.github.tomakehurst.wiremock.client.WireMock.delete
 import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.noContent
 import com.github.tomakehurst.wiremock.client.WireMock.ok
 import com.github.tomakehurst.wiremock.client.WireMock.okJson
 import com.github.tomakehurst.wiremock.client.WireMock.patch
@@ -23,6 +24,7 @@ import no.nav.tilleggsstonader.integrasjoner.util.ProblemDetailUtil.catchProblem
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.ArkiverDokumentRequest
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.ArkiverDokumentResponse
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.AvsenderMottaker
+import no.nav.tilleggsstonader.kontrakter.dokarkiv.BulkOppdaterLogiskVedleggRequest
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.DokarkivBruker
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.Dokument
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.Dokumenttype
@@ -406,6 +408,27 @@ class DokarkivControllerTest : IntegrationTest() {
 
         assertThat(exception.httpStatus).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
         assertThat(exception.detail.detail).contains("sletting feilet")
+    }
+
+    @Test
+    fun `skal bulk oppdatere logiske vedlegg for et dokument`() {
+        stubFor(
+            put("/rest/journalpostapi/v1/dokumentInfo/321/logiskVedlegg/")
+                .willReturn(noContent()),
+        )
+
+        val response: ResponseEntity<String> =
+            restTemplate.exchange(
+                localhost("$DOKARKIV_URL/dokument/321/logiskVedlegg"),
+                HttpMethod.PUT,
+                HttpEntity(
+                    BulkOppdaterLogiskVedleggRequest(titler = listOf("Logisk vedlegg 1", "Logisk vedlegg 2")),
+                    headers,
+                ),
+            )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body).isEqualTo("321")
     }
 
     private fun gyldigDokarkivResponse(statusKode: Int? = null): String {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
![image](https://github.com/navikt/tilleggsstonader-integrasjoner/assets/21220467/2cde7d6b-d909-442b-9468-48c80792fb8b)
Ved journalføring kan saksbehandler velge å legge til annet innhold i et dokument. Dette settes på feltet logiskeVedlegg. Må derfor kunne oppdatere dette.
