### PR TITLE
Tjeneste for å hente ut informasjon om saksbehandler fra AD

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 val javaVersion = JavaLanguageVersion.of(21)
 val springdocVersion = "2.5.0"
 val tilleggsstønaderLibsVersion = "2024.05.08-08.38.544e65c0c5a6"
-val tilleggsstønaderKontrakterVersion = "2024.06.14-11.28.434b4f2e5bda"
+val tilleggsstønaderKontrakterVersion = "2024.06.26-16.12.dc398a533db2"
 val tokenSupportVersion = "4.1.7"
 val springCloudVersion = "4.1.2"
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/client/AzureGraphRestClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/client/AzureGraphRestClient.kt
@@ -2,7 +2,6 @@ package no.nav.tilleggsstonader.integrasjoner.azure.client
 
 import no.nav.tilleggsstonader.integrasjoner.azure.domene.AzureAdBruker
 import no.nav.tilleggsstonader.integrasjoner.azure.domene.AzureAdBrukere
-import no.nav.tilleggsstonader.integrasjoner.azure.domene.Grupper
 import no.nav.tilleggsstonader.libs.http.client.AbstractRestClient
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
@@ -46,16 +45,8 @@ class AzureGraphRestClient(
         )
     }
 
-    fun hentSaksbehandler(): AzureAdBruker {
-        return getForEntity(saksbehandlerUri.toString())
-    }
-
     fun hentSaksbehandler(id: String): AzureAdBruker {
         return getForEntity(saksbehandlerUri(id).toString())
-    }
-
-    fun hentGrupper(): Grupper {
-        return getForEntity(grupperUri.toString())
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/client/AzureGraphRestClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/client/AzureGraphRestClient.kt
@@ -17,7 +17,6 @@ class AzureGraphRestClient(
     @Value("\${clients.azure-graph.uri}") private val aadGraphURI: URI,
 ) :
     AbstractRestClient(restTemplate) {
-    val saksbehandlerUri: URI = UriComponentsBuilder.fromUri(aadGraphURI).pathSegment(ME).build().toUri()
 
     fun saksbehandlerUri(id: String): URI =
         UriComponentsBuilder.fromUri(aadGraphURI)
@@ -34,8 +33,6 @@ class AzureGraphRestClient(
             .buildAndExpand(navIdent)
             .toUri()
 
-    val grupperUri: URI = UriComponentsBuilder.fromUri(aadGraphURI).pathSegment(ME, GRUPPER).build().toUri()
-
     fun finnSaksbehandler(navIdent: String): AzureAdBrukere {
         return getForEntity(
             saksbehandlersøkUri(navIdent).toString(),
@@ -50,9 +47,7 @@ class AzureGraphRestClient(
     }
 
     companion object {
-        private const val ME = "me"
         private const val USERS = "users"
-        private const val GRUPPER = "memberOf"
         private const val FELTER = "givenName,surname,onPremisesSamAccountName,id,userPrincipalName,streetAddress"
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/client/AzureGraphRestClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/client/AzureGraphRestClient.kt
@@ -1,0 +1,67 @@
+package no.nav.tilleggsstonader.integrasjoner.azure.client
+
+import no.nav.tilleggsstonader.integrasjoner.azure.domene.AzureAdBruker
+import no.nav.tilleggsstonader.integrasjoner.azure.domene.AzureAdBrukere
+import no.nav.tilleggsstonader.integrasjoner.azure.domene.Grupper
+import no.nav.tilleggsstonader.libs.http.client.AbstractRestClient
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpHeaders
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestTemplate
+import org.springframework.web.util.UriComponentsBuilder
+import java.net.URI
+
+@Service
+class AzureGraphRestClient(
+    @Qualifier("azure") restTemplate: RestTemplate,
+    @Value("\${AAD_GRAPH_API_URI}") private val aadGraphURI: URI,
+) :
+    AbstractRestClient(restTemplate) {
+    val saksbehandlerUri: URI = UriComponentsBuilder.fromUri(aadGraphURI).pathSegment(ME).build().toUri()
+
+    fun saksbehandlerUri(id: String): URI =
+        UriComponentsBuilder.fromUri(aadGraphURI)
+            .pathSegment(USERS, id)
+            .queryParam("\$select", FELTER)
+            .build()
+            .toUri()
+
+    fun saksbehandlersøkUri(navIdent: String): URI =
+        UriComponentsBuilder.fromUri(aadGraphURI)
+            .pathSegment(USERS)
+            .queryParam("\$search", "\"onPremisesSamAccountName:{navIdent}\"")
+            .queryParam("\$select", FELTER)
+            .buildAndExpand(navIdent)
+            .toUri()
+
+    val grupperUri: URI = UriComponentsBuilder.fromUri(aadGraphURI).pathSegment(ME, GRUPPER).build().toUri()
+
+    fun finnSaksbehandler(navIdent: String): AzureAdBrukere {
+        return getForEntity(
+            saksbehandlersøkUri(navIdent).toString(),
+            HttpHeaders().apply {
+                add("ConsistencyLevel", "eventual")
+            },
+        )
+    }
+
+    fun hentSaksbehandler(): AzureAdBruker {
+        return getForEntity(saksbehandlerUri.toString())
+    }
+
+    fun hentSaksbehandler(id: String): AzureAdBruker {
+        return getForEntity(saksbehandlerUri(id).toString())
+    }
+
+    fun hentGrupper(): Grupper {
+        return getForEntity(grupperUri.toString())
+    }
+
+    companion object {
+        private const val ME = "me"
+        private const val USERS = "users"
+        private const val GRUPPER = "memberOf"
+        private const val FELTER = "givenName,surname,onPremisesSamAccountName,id,userPrincipalName,streetAddress"
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/domene/AzureAdBruker.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/domene/AzureAdBruker.kt
@@ -1,0 +1,12 @@
+package no.nav.tilleggsstonader.integrasjoner.azure.domene
+
+import java.util.UUID
+
+data class AzureAdBruker(
+    val id: UUID,
+    val onPremisesSamAccountName: String,
+    val userPrincipalName: String,
+    val givenName: String,
+    val surname: String,
+    val streetAddress: String,
+)

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/domene/AzureAdBrukere.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/domene/AzureAdBrukere.kt
@@ -1,0 +1,3 @@
+package no.nav.tilleggsstonader.integrasjoner.azure.domene
+
+data class AzureAdBrukere(val value: List<AzureAdBruker>)

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/domene/Gruppe.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/domene/Gruppe.kt
@@ -1,0 +1,6 @@
+package no.nav.tilleggsstonader.integrasjoner.azure.domene
+
+data class Gruppe(
+    val id: String,
+    val onPremisesSamAccountName: String?,
+)

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/domene/Grupper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/domene/Grupper.kt
@@ -1,3 +1,0 @@
-package no.nav.tilleggsstonader.integrasjoner.azure.domene
-
-class Grupper(val value: List<Gruppe>)

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/domene/Grupper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/domene/Grupper.kt
@@ -1,0 +1,3 @@
+package no.nav.tilleggsstonader.integrasjoner.azure.domene
+
+class Grupper(val value: List<Gruppe>)

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/saksbehandler/SaksbehandlerController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/saksbehandler/SaksbehandlerController.kt
@@ -1,0 +1,21 @@
+package no.nav.tilleggsstonader.integrasjoner.saksbehandler
+
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import org.springframework.context.annotation.Profile
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping(value = ["/api/saksbehandler"])
+@Profile("!e2e")
+class SaksbehandlerController(private val saksbehandlerService: SaksbehandlerService) {
+    @GetMapping(path = ["/{id}"])
+    @ProtectedWithClaims(issuer = "azuread")
+    fun hentSaksbehandler(
+        @PathVariable id: String,
+    ): Ressurs<Saksbehandler> { // id kan være azure-id, e-post eller nav-ident
+        return Ressurs.success(saksbehandlerService.hentSaksbehandler(id), "Hent saksbehandler OK")
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/saksbehandler/SaksbehandlerController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/saksbehandler/SaksbehandlerController.kt
@@ -1,7 +1,7 @@
 package no.nav.tilleggsstonader.integrasjoner.saksbehandler
 
 import no.nav.security.token.support.core.api.ProtectedWithClaims
-import org.springframework.context.annotation.Profile
+import no.nav.tilleggsstonader.kontrakter.felles.Saksbehandler
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
@@ -9,13 +9,12 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping(value = ["/api/saksbehandler"])
-@Profile("!e2e")
 class SaksbehandlerController(private val saksbehandlerService: SaksbehandlerService) {
     @GetMapping(path = ["/{id}"])
     @ProtectedWithClaims(issuer = "azuread")
     fun hentSaksbehandler(
         @PathVariable id: String,
-    ): Ressurs<Saksbehandler> { // id kan være azure-id, e-post eller nav-ident
-        return Ressurs.success(saksbehandlerService.hentSaksbehandler(id), "Hent saksbehandler OK")
+    ): Saksbehandler { // id kan være azure-id, e-post eller nav-ident
+        return saksbehandlerService.hentSaksbehandler(id)
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/saksbehandler/SaksbehandlerService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/saksbehandler/SaksbehandlerService.kt
@@ -7,12 +7,12 @@ import java.util.UUID
 
 @Service
 class SaksbehandlerService(
-    private val azureGraphRestClient: AzureGraphRestClient
+    private val azureGraphRestClient: AzureGraphRestClient,
 ) {
     private val lengdeNavIdent = 7
 
     fun hentSaksbehandler(id: String): Saksbehandler {
-        //håntering av at operasjoner kan utføres av saksbehandlingsløsningen selv, og dermed ikke har ID i azure-ad
+        // håntering av at operasjoner kan utføres av saksbehandlingsløsningen selv, og dermed ikke har ID i azure-ad
         if (id == ID_VEDTAKSLØSNINGEN) {
             return Saksbehandler(
                 UUID.randomUUID(),

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/saksbehandler/SaksbehandlerService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/saksbehandler/SaksbehandlerService.kt
@@ -1,0 +1,64 @@
+package no.nav.tilleggsstonader.integrasjoner.saksbehandler
+
+import no.nav.tilleggsstonader.kontrakter.felles.Saksbehandler
+import org.springframework.core.env.Environment
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+@Service
+class SaksbehandlerService(
+    private val azureGraphRestClient: AzureGraphRestClient,
+    private val environment: Environment,
+) {
+    private val lengdeNavIdent = 7
+
+    fun hentSaksbehandler(id: String): Saksbehandler {
+        // TODO: Midlertidig for å få ut funksjonalitet. Fjern når ba-sak-e2e fases ut.
+        if (environment.activeProfiles.any { it == "e2e" }) {
+            return Saksbehandler(
+                azureId = UUID.randomUUID(),
+                navIdent = id,
+                fornavn = "Mocka",
+                etternavn = "Saksbehandler",
+                enhet = "4402",
+            )
+        }
+
+        if (id == ID_VEDTAKSLØSNINGEN) {
+            return Saksbehandler(
+                UUID.randomUUID(),
+                ID_VEDTAKSLØSNINGEN,
+                "Vedtaksløsning",
+                "Nav",
+                "9999",
+            )
+        }
+
+        val azureAdBruker =
+            if (id.length == lengdeNavIdent) {
+                val azureAdBrukere = azureGraphRestClient.finnSaksbehandler(id)
+
+                if (azureAdBrukere.value.size != 1) {
+                    error("Feil ved søk. Oppslag på navIdent $id returnerte ${azureAdBrukere.value.size} forekomster.")
+                }
+                azureAdBrukere.value.first()
+            } else {
+                azureGraphRestClient.hentSaksbehandler(id)
+            }
+
+        return Saksbehandler(
+            azureAdBruker.id,
+            azureAdBruker.onPremisesSamAccountName,
+            azureAdBruker.givenName,
+            azureAdBruker.surname,
+            azureAdBruker.streetAddress,
+        )
+    }
+
+    fun hentNavIdent(saksbehandlerId: String): String =
+        saksbehandlerId.takeIf { it.length == lengdeNavIdent } ?: hentSaksbehandler(saksbehandlerId).navIdent
+
+    companion object {
+        const val ID_VEDTAKSLØSNINGEN = "VL"
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/saksbehandler/SaksbehandlerService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/saksbehandler/SaksbehandlerService.kt
@@ -2,23 +2,22 @@ package no.nav.tilleggsstonader.integrasjoner.saksbehandler
 
 import no.nav.tilleggsstonader.integrasjoner.azure.client.AzureGraphRestClient
 import no.nav.tilleggsstonader.kontrakter.felles.Saksbehandler
-import org.springframework.core.env.Environment
 import org.springframework.stereotype.Service
 import java.util.UUID
 
 @Service
 class SaksbehandlerService(
-    private val azureGraphRestClient: AzureGraphRestClient,
-    private val environment: Environment,
+    private val azureGraphRestClient: AzureGraphRestClient
 ) {
     private val lengdeNavIdent = 7
 
     fun hentSaksbehandler(id: String): Saksbehandler {
+        //håntering av at operasjoner kan utføres av saksbehandlingsløsningen selv, og dermed ikke har ID i azure-ad
         if (id == ID_VEDTAKSLØSNINGEN) {
             return Saksbehandler(
                 UUID.randomUUID(),
                 ID_VEDTAKSLØSNINGEN,
-                "Vedtaksløsning",
+                "Tilleggsstønader Vedtakslønsning",
                 "Nav",
                 "9999",
             )

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/saksbehandler/SaksbehandlerService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/saksbehandler/SaksbehandlerService.kt
@@ -15,11 +15,11 @@ class SaksbehandlerService(
         // håntering av at operasjoner kan utføres av saksbehandlingsløsningen selv, og dermed ikke har ID i azure-ad
         if (id == ID_VEDTAKSLØSNINGEN) {
             return Saksbehandler(
-                UUID.randomUUID(),
-                ID_VEDTAKSLØSNINGEN,
-                "Tilleggsstønader Vedtakslønsning",
-                "Nav",
-                "9999",
+                azureId = UUID.randomUUID(),
+                navIdent = ID_VEDTAKSLØSNINGEN,
+                fornavn = "Tilleggsstønader Vedtaksløsning",
+                etternavn = "Nav",
+                enhet = "9999",
             )
         }
 
@@ -36,16 +36,13 @@ class SaksbehandlerService(
             }
 
         return Saksbehandler(
-            azureAdBruker.id,
-            azureAdBruker.onPremisesSamAccountName,
-            azureAdBruker.givenName,
-            azureAdBruker.surname,
-            azureAdBruker.streetAddress,
+            azureId = azureAdBruker.id,
+            navIdent = azureAdBruker.onPremisesSamAccountName,
+            fornavn = azureAdBruker.givenName,
+            etternavn = azureAdBruker.surname,
+            enhet = azureAdBruker.streetAddress, // sic!
         )
     }
-
-    fun hentNavIdent(saksbehandlerId: String): String =
-        saksbehandlerId.takeIf { it.length == lengdeNavIdent } ?: hentSaksbehandler(saksbehandlerId).navIdent
 
     companion object {
         const val ID_VEDTAKSLØSNINGEN = "VL"

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/saksbehandler/SaksbehandlerService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/saksbehandler/SaksbehandlerService.kt
@@ -1,5 +1,6 @@
 package no.nav.tilleggsstonader.integrasjoner.saksbehandler
 
+import no.nav.tilleggsstonader.integrasjoner.azure.client.AzureGraphRestClient
 import no.nav.tilleggsstonader.kontrakter.felles.Saksbehandler
 import org.springframework.core.env.Environment
 import org.springframework.stereotype.Service
@@ -13,17 +14,6 @@ class SaksbehandlerService(
     private val lengdeNavIdent = 7
 
     fun hentSaksbehandler(id: String): Saksbehandler {
-        // TODO: Midlertidig for å få ut funksjonalitet. Fjern når ba-sak-e2e fases ut.
-        if (environment.activeProfiles.any { it == "e2e" }) {
-            return Saksbehandler(
-                azureId = UUID.randomUUID(),
-                navIdent = id,
-                fornavn = "Mocka",
-                etternavn = "Saksbehandler",
-                enhet = "4402",
-            )
-        }
-
         if (id == ID_VEDTAKSLØSNINGEN) {
             return Saksbehandler(
                 UUID.randomUUID(),

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -28,24 +28,6 @@ no.nav.security.jwt:
     discoveryurl: ${AZURE_APP_WELL_KNOWN_URL}
     accepted_audience: ${AZURE_APP_CLIENT_ID}
   client.registration:
-    aad-graph-onbehalfof:
-      resource-url: ${AAD_GRAPH_API_URI}
-      token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
-      grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
-      scope: ${AAD_GRAPH_SCOPE}
-      authentication:
-        client-id: ${AZURE_APP_CLIENT_ID}
-        client-secret: ${AZURE_APP_CLIENT_SECRET}
-        client-auth-method: client_secret_basic
-    aad-graph:
-      resource-url: ${AAD_GRAPH_API_URI}
-      token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
-      grant-type: client_credentials
-      scope: ${AAD_GRAPH_SCOPE}
-      authentication:
-        client-id: ${AZURE_APP_CLIENT_ID}
-        client-secret: ${AZURE_APP_CLIENT_SECRET}
-        client-auth-method: client_secret_basic
     oppgave:
       resource-url: ${clients.oppgave.uri}
       token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
@@ -187,3 +169,7 @@ clients:
   etterlatte:
     uri: http://etterlatte-samordning-vedtak.etterlatte
     scope: api://${CLIENT_ENV}-gcp.etterlatte.etterlatte-samordning-vedtak/.default
+
+
+AAD_GRAPH_API_URI: https://graph.microsoft.com/v1.0/
+AAD_GRAPH_SCOPE: https://graph.microsoft.com/.default

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -28,6 +28,24 @@ no.nav.security.jwt:
     discoveryurl: ${AZURE_APP_WELL_KNOWN_URL}
     accepted_audience: ${AZURE_APP_CLIENT_ID}
   client.registration:
+    aad-graph-onbehalfof:
+      resource-url: ${AAD_GRAPH_API_URI}
+      token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
+      grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
+      scope: ${AAD_GRAPH_SCOPE}
+      authentication:
+        client-id: ${AZURE_APP_CLIENT_ID}
+        client-secret: ${AZURE_APP_CLIENT_SECRET}
+        client-auth-method: client_secret_basic
+    aad-graph:
+      resource-url: ${AAD_GRAPH_API_URI}
+      token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
+      grant-type: client_credentials
+      scope: ${AAD_GRAPH_SCOPE}
+      authentication:
+        client-id: ${AZURE_APP_CLIENT_ID}
+        client-secret: ${AZURE_APP_CLIENT_SECRET}
+        client-auth-method: client_secret_basic
     oppgave:
       resource-url: ${clients.oppgave.uri}
       token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}

--- a/src/test/kotlin/no/nav/tilleggsstonader/integrasjoner/IntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/integrasjoner/IntegrationTest.kt
@@ -25,6 +25,7 @@ import org.springframework.web.client.RestTemplate
     "mock-aap",
     "mock-enslig",
     "mock-etterlatte",
+    "mock-az-ad",
 )
 @EnableMockOAuth2Server
 abstract class IntegrationTest {

--- a/src/test/kotlin/no/nav/tilleggsstonader/integrasjoner/mocks/AzureADClientTestConfig.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/integrasjoner/mocks/AzureADClientTestConfig.kt
@@ -1,6 +1,5 @@
 package no.nav.tilleggsstonader.integrasjoner.mocks
 
-
 import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
@@ -27,11 +26,10 @@ class AzureADClientTestConfig {
     companion object {
         fun resetMock(client: AzureGraphRestClient) {
             clearMocks(client)
-            val responseHentSaksbehandler = AzureAdBruker(id = UUID.randomUUID(), onPremisesSamAccountName = "B857496", givenName = "Bob", surname = "Burger", streetAddress = "4402" , userPrincipalName = "Bob Burger"  )
+            val responseHentSaksbehandler = AzureAdBruker(id = UUID.randomUUID(), onPremisesSamAccountName = "B857496", givenName = "Bob", surname = "Burger", streetAddress = "4402", userPrincipalName = "Bob Burger")
             val responseFinnSaksbehandler = AzureAdBrukere(listOf(responseHentSaksbehandler))
             every { client.hentSaksbehandler(any()) } returns responseHentSaksbehandler
             every { client.finnSaksbehandler(any()) } returns responseFinnSaksbehandler
         }
     }
 }
-

--- a/src/test/kotlin/no/nav/tilleggsstonader/integrasjoner/mocks/AzureADClientTestConfig.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/integrasjoner/mocks/AzureADClientTestConfig.kt
@@ -1,0 +1,37 @@
+package no.nav.tilleggsstonader.integrasjoner.mocks
+
+
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.tilleggsstonader.integrasjoner.azure.client.AzureGraphRestClient
+import no.nav.tilleggsstonader.integrasjoner.azure.domene.AzureAdBruker
+import no.nav.tilleggsstonader.integrasjoner.azure.domene.AzureAdBrukere
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+import org.springframework.context.annotation.Profile
+import java.util.*
+
+@Configuration
+@Profile("mock-az-ad")
+class AzureADClientTestConfig {
+    @Bean
+    @Primary
+    fun azureadClient(): AzureGraphRestClient {
+        val client = mockk<AzureGraphRestClient>()
+        resetMock(client)
+        return client
+    }
+
+    companion object {
+        fun resetMock(client: AzureGraphRestClient) {
+            clearMocks(client)
+            val responseHentSaksbehandler = AzureAdBruker(id = UUID.randomUUID(), onPremisesSamAccountName = "B857496", givenName = "Bob", surname = "Burger", streetAddress = "4402" , userPrincipalName = "Bob Burger"  )
+            val responseFinnSaksbehandler = AzureAdBrukere(listOf(responseHentSaksbehandler))
+            every { client.hentSaksbehandler(any()) } returns responseHentSaksbehandler
+            every { client.finnSaksbehandler(any()) } returns responseFinnSaksbehandler
+        }
+    }
+}
+

--- a/src/test/kotlin/no/nav/tilleggsstonader/integrasjoner/saksbehandler/SaksbehandlerControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/integrasjoner/saksbehandler/SaksbehandlerControllerTest.kt
@@ -1,0 +1,54 @@
+package no.nav.tilleggsstonader.integrasjoner.saksbehandler
+
+import no.nav.tilleggsstonader.integrasjoner.IntegrationTest
+import no.nav.tilleggsstonader.integrasjoner.azure.client.AzureGraphRestClient
+import no.nav.tilleggsstonader.integrasjoner.mocks.AzureADClientTestConfig
+
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+import java.util.UUID
+
+
+class SaksbehandlerControllerTest() :IntegrationTest()  {
+    @Autowired
+    lateinit var azureGraphRestClient: AzureGraphRestClient
+    @Autowired
+    lateinit var saksbehandlerService: SaksbehandlerService
+
+    @BeforeEach
+    fun setUp() {
+        AzureADClientTestConfig.resetMock(azureGraphRestClient)
+    }
+
+
+    @Test
+    fun `skal kalle korrekt tjeneste for oppslag på id`() {
+        val id = UUID.randomUUID()
+        val saksbehandler = saksbehandlerService.hentSaksbehandler(id.toString())
+
+        assertThat(saksbehandler.fornavn).isEqualTo("Bob")
+        assertThat(saksbehandler.etternavn).isEqualTo("Burger")
+        assertThat(saksbehandler.navIdent).isEqualTo("B857496")
+        assertThat(saksbehandler.enhet).isEqualTo("4402")
+    }
+
+    @Test
+    fun `skal kalle korrekt tjeneste for oppslag på navIdent`() {
+        val navIdent = "B857496"
+        val saksbehandler = saksbehandlerService.hentSaksbehandler(navIdent)
+
+        assertThat(saksbehandler.fornavn).isEqualTo("Bob")
+        assertThat(saksbehandler.etternavn).isEqualTo("Burger")
+        assertThat(saksbehandler.navIdent).isEqualTo(navIdent)
+        assertThat(saksbehandler.enhet).isEqualTo("4402")
+    }
+
+    companion object {
+        const val BASE_URL = "/api/saksbehandler"
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/integrasjoner/saksbehandler/SaksbehandlerControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/integrasjoner/saksbehandler/SaksbehandlerControllerTest.kt
@@ -3,20 +3,16 @@ package no.nav.tilleggsstonader.integrasjoner.saksbehandler
 import no.nav.tilleggsstonader.integrasjoner.IntegrationTest
 import no.nav.tilleggsstonader.integrasjoner.azure.client.AzureGraphRestClient
 import no.nav.tilleggsstonader.integrasjoner.mocks.AzureADClientTestConfig
-
-
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-
 import java.util.UUID
 
-
-class SaksbehandlerControllerTest() :IntegrationTest()  {
+class SaksbehandlerControllerTest() : IntegrationTest() {
     @Autowired
     lateinit var azureGraphRestClient: AzureGraphRestClient
+
     @Autowired
     lateinit var saksbehandlerService: SaksbehandlerService
 
@@ -24,7 +20,6 @@ class SaksbehandlerControllerTest() :IntegrationTest()  {
     fun setUp() {
         AzureADClientTestConfig.resetMock(azureGraphRestClient)
     }
-
 
     @Test
     fun `skal kalle korrekt tjeneste for oppslag på id`() {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Til byr tjeneste for tilleggstøander knyttet til saksbehandlers organisasjonelle enhet.
Integasjon mot azureAD.