### PR TITLE
AzureGraphClient bruker restOperations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,6 +71,9 @@ dependencies {
 
     implementation("no.nav.tilleggsstonader.kontrakter:tilleggsstonader-kontrakter:$tilleggsstønaderKontrakterVersion")
 
+    //azure ad-hack
+    implementation("no.nav.familie.felles:http-client:3.20240515152313_9dd5659")
+
     // Test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.cloud:spring-cloud-contract-wiremock:$springCloudVersion")

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/client/AzureGraphRestClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/client/AzureGraphRestClient.kt
@@ -13,7 +13,7 @@ import java.net.URI
 
 @Service
 class AzureGraphRestClient(
-    @Qualifier("utenAuth") restTemplate: RestTemplate,
+    @Qualifier("jwtBearer") restTemplate: RestTemplate,
     @Value("\${clients.azure-graph.uri}") private val aadGraphURI: URI,
 ) :
     AbstractRestClient(restTemplate) {

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/client/AzureGraphRestClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/client/AzureGraphRestClient.kt
@@ -32,7 +32,6 @@ class AzureGraphRestClient(
             .queryParam("\$select", FELTER)
             .encode().toUriString()
 
-
     fun finnSaksbehandler(navIdent: String): AzureAdBrukere {
         return getForEntity(
             saksbehandlersøkUri(navIdent).toString(),

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/client/AzureGraphRestClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/client/AzureGraphRestClient.kt
@@ -3,13 +3,11 @@ package no.nav.tilleggsstonader.integrasjoner.azure.client
 import no.nav.familie.http.client.AbstractRestClient
 import no.nav.tilleggsstonader.integrasjoner.azure.domene.AzureAdBruker
 import no.nav.tilleggsstonader.integrasjoner.azure.domene.AzureAdBrukere
-
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpHeaders
 import org.springframework.stereotype.Service
 import org.springframework.web.client.RestOperations
-import org.springframework.web.client.RestTemplate
 import org.springframework.web.util.UriComponentsBuilder
 import java.net.URI
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/client/AzureGraphRestClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/client/AzureGraphRestClient.kt
@@ -18,12 +18,12 @@ class AzureGraphRestClient(
 ) :
     AbstractRestClient(restTemplate) {
 
-    fun saksbehandlerUri(id: String): URI =
+    fun saksbehandlerUri(id: String): String =
         UriComponentsBuilder.fromUri(aadGraphURI)
             .pathSegment(USERS, id)
             .queryParam("\$select", FELTER)
             .build()
-            .toUri()
+            .toUriString()
 
     fun saksbehandlersøkUri(navIdent: String): URI =
         UriComponentsBuilder.fromUri(aadGraphURI)
@@ -43,7 +43,7 @@ class AzureGraphRestClient(
     }
 
     fun hentSaksbehandler(id: String): AzureAdBruker {
-        return getForEntity(saksbehandlerUri(id).toString())
+        return getForEntity(saksbehandlerUri(id))
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/client/AzureGraphRestClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/client/AzureGraphRestClient.kt
@@ -13,7 +13,7 @@ import java.net.URI
 
 @Service
 class AzureGraphRestClient(
-    @Qualifier("jwtBearer") restTemplate: RestTemplate,
+    @Qualifier("azure") restTemplate: RestTemplate,
     @Value("\${clients.azure-graph.uri}") private val aadGraphURI: URI,
 ) :
     AbstractRestClient(restTemplate) {
@@ -25,13 +25,13 @@ class AzureGraphRestClient(
             .build()
             .toUri()
 
-    fun saksbehandlersøkUri(navIdent: String): URI =
+    fun saksbehandlersøkUri(navIdent: String): String =
         UriComponentsBuilder.fromUri(aadGraphURI)
             .pathSegment(USERS)
-            .queryParam("\$search", FELTSØKPARAM)
+            .queryParam("\$search", "\"onPremisesSamAccountName:{navIdent}\"")
             .queryParam("\$select", FELTER)
-            .buildAndExpand(navIdent)
-            .toUri()
+            .encode().toUriString()
+
 
     fun finnSaksbehandler(navIdent: String): AzureAdBrukere {
         return getForEntity(
@@ -49,6 +49,5 @@ class AzureGraphRestClient(
     companion object {
         private const val USERS = "users"
         private const val FELTER = "givenName,surname,onPremisesSamAccountName,id,userPrincipalName,streetAddress"
-        private const val FELTSØKPARAM = "onPremisesSamAccountName:{navIdent}"
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/client/AzureGraphRestClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/client/AzureGraphRestClient.kt
@@ -28,7 +28,7 @@ class AzureGraphRestClient(
     fun saksbehandlersøkUri(navIdent: String): URI =
         UriComponentsBuilder.fromUri(aadGraphURI)
             .pathSegment(USERS)
-            .queryParam("\$search", "\"onPremisesSamAccountName:{navIdent}\"")
+            .queryParam("\$search", FELTSØKPARAM)
             .queryParam("\$select", FELTER)
             .buildAndExpand(navIdent)
             .toUri()
@@ -49,5 +49,6 @@ class AzureGraphRestClient(
     companion object {
         private const val USERS = "users"
         private const val FELTER = "givenName,surname,onPremisesSamAccountName,id,userPrincipalName,streetAddress"
+        private const val FELTSØKPARAM = "onPremisesSamAccountName:{navIdent}"
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/client/AzureGraphRestClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/client/AzureGraphRestClient.kt
@@ -11,6 +11,10 @@ import org.springframework.web.client.RestOperations
 import org.springframework.web.util.UriComponentsBuilder
 import java.net.URI
 
+/**  TODO: Bruker familie sin AbstractRestClient og RestOperations for å få at kallet går igjennom til Azure
+ * se favro for forklaring og hva problemet er https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21832
+ */
+
 @Service
 class AzureGraphRestClient(
     @Qualifier("azure") restTemplate: RestOperations,
@@ -28,7 +32,7 @@ class AzureGraphRestClient(
     fun saksbehandlersøkUri(navIdent: String): URI =
         UriComponentsBuilder.fromUri(aadGraphURI)
             .pathSegment(USERS)
-            .queryParam("\$search", "\"onPremisesSamAccountName:{navIdent}\"")
+            .queryParam("\$search", "\"onPremisesSamAccountName:{navIdent}\"") // Denne linjen blir det feilencoding på mot azureGraph
             .queryParam("\$select", FELTER)
             .buildAndExpand(navIdent)
             .toUri()

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/client/AzureGraphRestClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/client/AzureGraphRestClient.kt
@@ -20,7 +20,7 @@ class AzureGraphRestClient(
     @Qualifier("azure") restTemplate: RestOperations,
     @Value("\${clients.azure-graph.uri}") private val aadGraphURI: URI,
 ) :
-    AbstractRestClient(restTemplate, "azureGraph test") {
+    AbstractRestClient(restTemplate, "azureGraph-ts-integrasjoner") {
 
     fun saksbehandlerUri(id: String): URI =
         UriComponentsBuilder.fromUri(aadGraphURI)

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/client/AzureGraphRestClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/client/AzureGraphRestClient.kt
@@ -13,17 +13,17 @@ import java.net.URI
 
 @Service
 class AzureGraphRestClient(
-    @Qualifier("azure") restTemplate: RestTemplate,
+    @Qualifier("utenAuth") restTemplate: RestTemplate,
     @Value("\${clients.azure-graph.uri}") private val aadGraphURI: URI,
 ) :
     AbstractRestClient(restTemplate) {
 
-    fun saksbehandlerUri(id: String): String =
+    fun saksbehandlerUri(id: String): URI =
         UriComponentsBuilder.fromUri(aadGraphURI)
             .pathSegment(USERS, id)
             .queryParam("\$select", FELTER)
             .build()
-            .toUriString()
+            .toUri()
 
     fun saksbehandlersøkUri(navIdent: String): URI =
         UriComponentsBuilder.fromUri(aadGraphURI)
@@ -43,7 +43,7 @@ class AzureGraphRestClient(
     }
 
     fun hentSaksbehandler(id: String): AzureAdBruker {
-        return getForEntity(saksbehandlerUri(id))
+        return getForEntity(saksbehandlerUri(id).toString())
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/client/AzureGraphRestClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/azure/client/AzureGraphRestClient.kt
@@ -30,6 +30,7 @@ class AzureGraphRestClient(
             .pathSegment(USERS)
             .queryParam("\$search", "\"onPremisesSamAccountName:{navIdent}\"")
             .queryParam("\$select", FELTER)
+            .buildAndExpand(navIdent)
             .encode().toUriString()
 
     fun finnSaksbehandler(navIdent: String): AzureAdBrukere {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -154,25 +154,6 @@ no.nav.security.jwt:
        client-secret: ${AZURE_APP_CLIENT_SECRET}
        client-auth-method: client_secret_basic
 
-    aad-graph-onbehalfof:
-      resource-url: ${AAD_GRAPH_API_URI}
-      token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
-      grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
-      scope: ${AAD_GRAPH_SCOPE}
-      authentication:
-        client-id: ${AZURE_APP_CLIENT_ID}
-        client-secret: ${AZURE_APP_CLIENT_SECRET}
-        client-auth-method: client_secret_basic
-    aad-graph:
-      resource-url: ${AAD_GRAPH_API_URI}
-      token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
-      grant-type: client_credentials
-      scope: ${AAD_GRAPH_SCOPE}
-      authentication:
-        client-id: ${AZURE_APP_CLIENT_ID}
-        client-secret: ${AZURE_APP_CLIENT_SECRET}
-        client-auth-method: client_secret_basic
-
 clients:
   arena:
     uri: https://arena-api.prod-fss-pub.nais.io

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -154,6 +154,25 @@ no.nav.security.jwt:
        client-secret: ${AZURE_APP_CLIENT_SECRET}
        client-auth-method: client_secret_basic
 
+    aad-graph-onbehalfof:
+      resource-url: ${AAD_GRAPH_API_URI}
+      token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
+      grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
+      scope: ${AAD_GRAPH_SCOPE}
+      authentication:
+        client-id: ${AZURE_APP_CLIENT_ID}
+        client-secret: ${AZURE_APP_CLIENT_SECRET}
+        client-auth-method: client_secret_basic
+    aad-graph:
+      resource-url: ${AAD_GRAPH_API_URI}
+      token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
+      grant-type: client_credentials
+      scope: ${AAD_GRAPH_SCOPE}
+      authentication:
+        client-id: ${AZURE_APP_CLIENT_ID}
+        client-secret: ${AZURE_APP_CLIENT_SECRET}
+        client-auth-method: client_secret_basic
+
 clients:
   arena:
     uri: https://arena-api.prod-fss-pub.nais.io


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ved bruk av egen AbstractRestClient og RestTemplate så feiler kallet mot Azure Graph.
Som ein midlertidig fiks tar dette kallet i bruk familie sin versjon og RESTOperations. 