### PR TITLE
Ny endepunkt for å hente aap-perioder sammen med aktivitetsfase for å…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 val javaVersion = JavaLanguageVersion.of(21)
 val springdocVersion = "2.5.0"
 val tilleggsstønaderLibsVersion = "2024.07.15-13.17.6c84c810950d"
-val tilleggsstønaderKontrakterVersion = "2024.08.12-08.20.e194558f350e"
+val tilleggsstønaderKontrakterVersion = "2024.08.14-17.17.7812164fb0d8"
 val tokenSupportVersion = "4.1.7"
 val springCloudVersion = "4.1.2"
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/aap/AAPClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/aap/AAPClient.kt
@@ -19,7 +19,7 @@ class AAPClient(
 ) : AbstractRestClient(restTemplate) {
 
     val uriPerioder = UriComponentsBuilder.fromUri(baseUrl)
-        .pathSegment("perioder")
+        .pathSegment("perioder", "aktivitetfase")
         .encode()
         .toUriString()
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/aap/AAPPerioderResponse.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/aap/AAPPerioderResponse.kt
@@ -3,7 +3,22 @@ package no.nav.tilleggsstonader.integrasjoner.aap
 import java.time.LocalDate
 
 data class AAPPerioderResponse(
-    val perioder: List<Periode>,
+    val perioder: List<AAPPeriode>,
+)
+
+/**
+ * Verdier på aktivitetsfaseKode/aktivitetsfaseNavn
+ * UA - Under arbeidsavklaring
+ * SPE - Sykepengeerstatning
+ * IKKE - Ikke spesif. aktivitetsfase
+ * UVUP - Vurdering for uføre
+ * AU - Arbeidsutprøving
+ * FA - Ferdig avklart
+ */
+data class AAPPeriode(
+    val aktivitetsfaseNavn: String,
+    val aktivitetsfaseKode: String,
+    val periode: Periode,
 )
 
 data class Periode(

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/ytelse/YtelseService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/ytelse/YtelseService.kt
@@ -78,8 +78,9 @@ class YtelseService(
         return perioder.perioder.map {
             YtelsePeriode(
                 type = TypeYtelsePeriode.AAP,
-                fom = it.fraOgMedDato,
-                tom = it.tilOgMedDato,
+                fom = it.periode.fraOgMedDato,
+                tom = it.periode.tilOgMedDato,
+                aapErFerdigAvklart = it.aktivitetsfaseNavn == "Ferdig avklart",
             )
         }
     }

--- a/src/test/kotlin/no/nav/tilleggsstonader/integrasjoner/mocks/AAPClientTestConfig.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/integrasjoner/mocks/AAPClientTestConfig.kt
@@ -4,6 +4,7 @@ import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.tilleggsstonader.integrasjoner.aap.AAPClient
+import no.nav.tilleggsstonader.integrasjoner.aap.AAPPeriode
 import no.nav.tilleggsstonader.integrasjoner.aap.AAPPerioderResponse
 import no.nav.tilleggsstonader.integrasjoner.aap.Periode
 import org.springframework.context.annotation.Bean
@@ -25,9 +26,14 @@ class AAPClientTestConfig {
     }
 
     companion object {
+        private val periode = AAPPeriode(
+            aktivitetsfaseNavn = "Arbeidsutprøving",
+            aktivitetsfaseKode = "AU",
+            periode = Periode(LocalDate.now(), LocalDate.now()),
+        )
         fun resetMock(client: AAPClient) {
             clearMocks(client)
-            every { client.hentPerioder(any(), any(), any()) } returns AAPPerioderResponse(listOf(Periode(LocalDate.now(), LocalDate.now())))
+            every { client.hentPerioder(any(), any(), any()) } returns AAPPerioderResponse(listOf(periode))
         }
     }
 }


### PR DESCRIPTION
… kunne si om en periode har status ferdig avklart som ikke gir rett på tilsyn barn

### Hvorfor er denne endringen nødvendig? ✨
Vi henter perioder fra AAP som gir rett på våre stønader 
Dersom en periode har aktivitetsfase "ferdig avklart" gir den ikke rett på tilsyn barn.


https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21588