### PR TITLE
Oppdaterer scope for dokdistfordeling

### DIFF
--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -10,9 +10,6 @@ clients:
   dokarkiv:
     uri: https://dokarkiv-q2.dev-fss-pub.nais.io
     scope: api://${CLIENT_ENV}-fss.teamdokumenthandtering.dokarkiv/.default
-  dokdist:
-    uri: https://dokdistfordeling.dev-fss-pub.nais.io # kjører i q2
-    scope: api://${CLIENT_ENV}-fss.teamdokumenthandtering.saf/.default
   saf:
     uri: https://saf-q2.dev-fss-pub.nais.io # kjører i q2
     scope: api://${CLIENT_ENV}-fss.teamdokumenthandtering.saf/.default

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -206,8 +206,8 @@ clients:
     uri: https://dokarkiv.prod-fss-pub.nais.io
     scope: api://${CLIENT_ENV}-fss.teamdokumenthandtering.dokarkiv/.default
   dokdist:
-    uri: https://dokdistfordeling.prod-fss-pub.nais.io
-    scope: api://${CLIENT_ENV}-fss.teamdokumenthandtering.saf/.default
+    uri: https://dokdistfordeling.${CLIENT_ENV}-fss-pub.nais.io
+    scope: api://${CLIENT_ENV}-fss.teamdokumenthandtering.dokdistfordeling/.default
   saf:
     uri: https://saf.prod-fss-pub.nais.io
     scope: api://${CLIENT_ENV}-fss.teamdokumenthandtering.saf/.default


### PR DESCRIPTION
Kun laget PR for å følge opp PR når jeg fått verifisert dev på nytt, virker som noe feiler
https://nav-it.slack.com/archives/C6W9E5GPJ/p1755500828753069

### Endring:
* Fra saf-scope til dokdistfordeling-scope
Som annonsert: https://nav-it.slack.com/archives/C06Q2T7TCJG/p1754469824098999

> Vi gjør endringer på autentisering i dokdistfordeling, for å sørge for at autentisering med EntraID er implementert som tiltenkt. Pr i dag kalles distribuerJournalpost med EntraID tokens scopet mot SAF, hvor dokdistfordeling proxyer dette tokenet videre i kall til SAF. Vi ønsker på sikt å endre dette til av dokdistfordeling kun kan kalles med tokens som er scopet mot seg selv. Steg 1 av denne endringen innføres nå, hvor dokdistfordeling i en overgangsperiode vil akseptere tokens med enten saf- eller dokdistfordeling-scope. Dette innebærer at konsumenter ikke trenger å gjøre noe umiddelbart, men på sikt (helst så snart som mulig) må endre scope for tokenet de kaller dokdistfordeling med. Vi kommer til å bistå konsumenter med denne endringen. Liste med pre-autentiserte applikasjoner er populert for hvert miljø basert på kall mot distribuertJournalpost siste 7 dager.