### PR TITLE
Korriger url for kall til logiskVedlegg på dokarkiv

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/client/DokarkivLogiskVedleggRestClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/client/DokarkivLogiskVedleggRestClient.kt
@@ -101,7 +101,7 @@ class DokarkivLogiskVedleggRestClient(
     }
 
     companion object {
-        private const val PATH_LOGISKVEDLEGG = "rest/journalpostapi/v1/dokumentInfo/{dokumentInfo}/logiskVedlegg/"
+        private const val PATH_LOGISKVEDLEGG = "rest/journalpostapi/v1/dokumentInfo/{dokumentInfo}/logiskVedlegg"
         private const val PATH_SLETT_LOGISK_VEDLEGG = "$PATH_LOGISKVEDLEGG/{logiskVedleggId}"
 
         private const val NAV_CALL_ID = "Nav-Callid"

--- a/src/test/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/DokarkivControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/DokarkivControllerTest.kt
@@ -370,7 +370,7 @@ class DokarkivControllerTest : IntegrationTest() {
     @Test
     fun `skal opprette logisk vedlegg`() {
         stubFor(
-            post("/rest/journalpostapi/v1/dokumentInfo/321/logiskVedlegg/")
+            post("/rest/journalpostapi/v1/dokumentInfo/321/logiskVedlegg")
                 .willReturn(okJson(jsonMapper.writeValueAsString(LogiskVedleggResponse(21L)))),
         )
 
@@ -388,7 +388,7 @@ class DokarkivControllerTest : IntegrationTest() {
     @Test
     fun `skal returnere feil hvis man ikke kan opprette logisk vedlegg`() {
         stubFor(
-            post("/rest/journalpostapi/v1/dokumentInfo/321/logiskVedlegg/")
+            post("/rest/journalpostapi/v1/dokumentInfo/321/logiskVedlegg")
                 .willReturn(aResponse().withStatus(404).withBody("melding fra klient")),
         )
 
@@ -446,7 +446,7 @@ class DokarkivControllerTest : IntegrationTest() {
     @Test
     fun `skal bulk oppdatere logiske vedlegg for et dokument`() {
         stubFor(
-            put("/rest/journalpostapi/v1/dokumentInfo/321/logiskVedlegg/")
+            put("/rest/journalpostapi/v1/dokumentInfo/321/logiskVedlegg")
                 .willReturn(noContent()),
         )
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Dokarkiv vil snart ikke godta kall til paths med trailing slash, derfor må den fjernes for å unngå problemer