### PR TITLE
Oppdater kontrakter-versjon med nye stønadstyper for flytting tso/tsr

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ val javaVersion = JavaLanguageVersion.of(21)
 val tomcatVersion = "11.0.22"
 val springdocVersion = "3.1.0"
 val tilleggsstønaderLibsVersion = "2026.05.06-12.26.7cb4f43fb62a"
-val tilleggsstønaderKontrakterVersion = "1"
+val tilleggsstønaderKontrakterVersion = "2026.08.18-10.22.815df0ee133f"
 val tokenSupportVersion = "6.0.11"
 val wiremockSpringVersion = "4.2.2"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ val javaVersion = JavaLanguageVersion.of(21)
 val tomcatVersion = "11.0.22"
 val springdocVersion = "3.1.0"
 val tilleggsstønaderLibsVersion = "2026.05.06-12.26.7cb4f43fb62a"
-val tilleggsstønaderKontrakterVersion = "2026.08.13-10.12.b6ff16f9c72f"
+val tilleggsstønaderKontrakterVersion = "1"
 val tokenSupportVersion = "6.0.11"
 val wiremockSpringVersion = "4.2.2"
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/metadata/Dokumentmetadata.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/metadata/Dokumentmetadata.kt
@@ -84,4 +84,20 @@ fun Dokumenttype.tilMetadata(): Dokumentmetadata =
         Dokumenttype.REISE_TIL_SAMLING_TSO_INTERNT_VEDTAK -> ReiseTilSamlingTsoInterntVedtakMetadata
         Dokumenttype.REISE_TIL_SAMLING_TSO_KLAGE_VEDTAKSBREV -> ReiseTilSamlingTsoKlageVedtak
         Dokumenttype.REISE_TIL_SAMLING_TSO_KLAGE_INTERNT_VEDTAK -> ReiseTilSamlingTsoKlageInterntVedtak
+
+        Dokumenttype.FLYTTING_TSO_SØKNAD -> FlyttingTsoSøknadMetadata
+        Dokumenttype.FLYTTING_TSO_SØKNAD_VEDLEGG -> FlyttingTsoSøknadVedleggMetadata
+        Dokumenttype.FLYTTING_TSO_VEDTAKSBREV -> FlyttingTsoVedtaksbrevMetadata
+        Dokumenttype.FLYTTING_TSO_FRITTSTÅENDE_BREV -> FlyttingTsoFrittståendeBrevMetadata
+        Dokumenttype.FLYTTING_TSO_INTERNT_VEDTAK -> FlyttingTsoInterntVedtakMetadata
+        Dokumenttype.FLYTTING_TSO_KLAGE_VEDTAKSBREV -> FlyttingTsoKlageVedtak
+        Dokumenttype.FLYTTING_TSO_KLAGE_INTERNT_VEDTAK -> FlyttingTsoKlageInterntVedtak
+
+        Dokumenttype.FLYTTING_TSR_SØKNAD -> FlyttingTsrSøknadMetadata
+        Dokumenttype.FLYTTING_TSR_SØKNAD_VEDLEGG -> FlyttingTsrSøknadVedleggMetadata
+        Dokumenttype.FLYTTING_TSR_VEDTAKSBREV -> FlyttingTsrVedtaksbrevMetadata
+        Dokumenttype.FLYTTING_TSR_FRITTSTÅENDE_BREV -> FlyttingTsrFrittståendeBrevMetadata
+        Dokumenttype.FLYTTING_TSR_INTERNT_VEDTAK -> FlyttingTsrInterntVedtakMetadata
+        Dokumenttype.FLYTTING_TSR_KLAGE_VEDTAKSBREV -> FlyttingTsrKlageVedtak
+        Dokumenttype.FLYTTING_TSR_KLAGE_INTERNT_VEDTAK -> FlyttingTsrKlageInterntVedtak
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/metadata/Dokumentmetadata.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/metadata/Dokumentmetadata.kt
@@ -77,13 +77,21 @@ fun Dokumenttype.tilMetadata(): Dokumentmetadata =
         Dokumenttype.DAGLIG_REISE_TSR_KJØRELISTE_VEDLEGG -> DagligReiseTsrKjørelisteVedlegg
 
         // Setter tema TSO som default, så er det opp til Sak å eventuelt endre dette før journalposten ferdigstilles.
-        Dokumenttype.REISE_TIL_SAMLING_SØKNAD -> ReiseTilSamlingTsoSøknadMetadata
-        Dokumenttype.REISE_TIL_SAMLING_SØKNAD_VEDLEGG -> ReiseTilSamlingTsoSøknadVedleggMetadata
+        Dokumenttype.REISE_TIL_SAMLING_TSO_SØKNAD -> ReiseTilSamlingTsoSøknadMetadata
+        Dokumenttype.REISE_TIL_SAMLING_TSO_SØKNAD_VEDLEGG -> ReiseTilSamlingTsoSøknadVedleggMetadata
         Dokumenttype.REISE_TIL_SAMLING_TSO_VEDTAKSBREV -> ReiseTilSamlingTsoVedtaksbrevMetadata
         Dokumenttype.REISE_TIL_SAMLING_TSO_FRITTSTÅENDE_BREV -> ReiseTilSamlingTsoFrittståendeBrevMetadata
         Dokumenttype.REISE_TIL_SAMLING_TSO_INTERNT_VEDTAK -> ReiseTilSamlingTsoInterntVedtakMetadata
         Dokumenttype.REISE_TIL_SAMLING_TSO_KLAGE_VEDTAKSBREV -> ReiseTilSamlingTsoKlageVedtak
         Dokumenttype.REISE_TIL_SAMLING_TSO_KLAGE_INTERNT_VEDTAK -> ReiseTilSamlingTsoKlageInterntVedtak
+
+        Dokumenttype.REISE_TIL_SAMLING_TSR_SØKNAD -> ReiseTilSamlingTsrSøknadMetadata
+        Dokumenttype.REISE_TIL_SAMLING_TSR_SØKNAD_VEDLEGG -> ReiseTilSamlingTsrSøknadVedleggMetadata
+        Dokumenttype.REISE_TIL_SAMLING_TSR_VEDTAKSBREV -> ReiseTilSamlingTsrVedtaksbrevMetadata
+        Dokumenttype.REISE_TIL_SAMLING_TSR_FRITTSTÅENDE_BREV -> ReiseTilSamlingTsrFrittståendeBrevMetadata
+        Dokumenttype.REISE_TIL_SAMLING_TSR_INTERNT_VEDTAK -> ReiseTilSamlingTsrInterntVedtakMetadata
+        Dokumenttype.REISE_TIL_SAMLING_TSR_KLAGE_VEDTAKSBREV -> ReiseTilSamlingTsrKlageVedtak
+        Dokumenttype.REISE_TIL_SAMLING_TSR_KLAGE_INTERNT_VEDTAK -> ReiseTilSamlingTsrKlageInterntVedtak
 
         Dokumenttype.FLYTTING_TSO_SØKNAD -> FlyttingTsoSøknadMetadata
         Dokumenttype.FLYTTING_TSO_SØKNAD_VEDLEGG -> FlyttingTsoSøknadVedleggMetadata

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/metadata/MetadataFlytting.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/metadata/MetadataFlytting.kt
@@ -1,0 +1,110 @@
+package no.nav.tilleggsstonader.integrasjoner.dokarkiv.metadata
+
+import no.nav.tilleggsstonader.kontrakter.dokarkiv.Dokumenttype
+import no.nav.tilleggsstonader.kontrakter.felles.Behandlingstema
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.kontrakter.felles.Tema
+import no.nav.tilleggsstonader.kontrakter.sak.DokumentBrevkode
+import org.springframework.stereotype.Component
+
+@Component
+data object FlyttingTsoSøknadMetadata : SøknadMetadata(
+    tema = Tema.TSO,
+    behandlingstema = Behandlingstema.FlyttingTSO,
+    dokumenttype = Dokumenttype.FLYTTING_TSO_SØKNAD,
+    tittel = "Søknad om ${Stønadstype.FLYTTING_TSO.visningsnavn}",
+    brevkode = DokumentBrevkode.FLYTTING.verdi,
+)
+
+@Component
+data object FlyttingTsoSøknadVedleggMetadata : SøknadVedleggMetadata(
+    tema = Tema.TSO,
+    dokumenttype = Dokumenttype.FLYTTING_TSO_SØKNAD_VEDLEGG,
+)
+
+@Component
+data object FlyttingTsoFrittståendeBrevMetadata : FrittståendeBrevMetadata(
+    tema = Tema.TSO,
+    behandlingstema = Behandlingstema.FlyttingTSO,
+    dokumenttype = Dokumenttype.FLYTTING_TSO_FRITTSTÅENDE_BREV,
+)
+
+@Component
+data object FlyttingTsoInterntVedtakMetadata : InterntVedtakBrevMetadata(
+    tema = Tema.TSO,
+    behandlingstema = Behandlingstema.FlyttingTSO,
+    dokumenttype = Dokumenttype.FLYTTING_TSO_INTERNT_VEDTAK,
+    tittel = "Internt vedtak flytting",
+)
+
+@Component
+data object FlyttingTsoVedtaksbrevMetadata : VedtaksbrevMetadata(
+    tema = Tema.TSO,
+    behandlingstema = Behandlingstema.FlyttingTSO,
+    dokumenttype = Dokumenttype.FLYTTING_TSO_VEDTAKSBREV,
+)
+
+@Component
+data object FlyttingTsoKlageInterntVedtak : KlageInterntVedtak(
+    tema = Tema.TSO,
+    behandlingstema = Behandlingstema.FlyttingTSO,
+    dokumenttype = Dokumenttype.FLYTTING_TSO_KLAGE_INTERNT_VEDTAK,
+)
+
+@Component
+data object FlyttingTsoKlageVedtak : KlageVedtak(
+    tema = Tema.TSO,
+    behandlingstema = Behandlingstema.FlyttingTSO,
+    dokumenttype = Dokumenttype.FLYTTING_TSO_KLAGE_VEDTAKSBREV,
+)
+
+@Component
+data object FlyttingTsrSøknadMetadata : SøknadMetadata(
+    tema = Tema.TSR,
+    behandlingstema = Behandlingstema.FlyttingTSR,
+    dokumenttype = Dokumenttype.FLYTTING_TSR_SØKNAD,
+    tittel = "Søknad om ${Stønadstype.FLYTTING_TSR.visningsnavn}",
+    brevkode = DokumentBrevkode.FLYTTING.verdi,
+)
+
+@Component
+data object FlyttingTsrSøknadVedleggMetadata : SøknadVedleggMetadata(
+    tema = Tema.TSR,
+    dokumenttype = Dokumenttype.FLYTTING_TSR_SØKNAD_VEDLEGG,
+)
+
+@Component
+data object FlyttingTsrFrittståendeBrevMetadata : FrittståendeBrevMetadata(
+    tema = Tema.TSR,
+    behandlingstema = Behandlingstema.FlyttingTSR,
+    dokumenttype = Dokumenttype.FLYTTING_TSR_FRITTSTÅENDE_BREV,
+)
+
+@Component
+data object FlyttingTsrInterntVedtakMetadata : InterntVedtakBrevMetadata(
+    tema = Tema.TSR,
+    behandlingstema = Behandlingstema.FlyttingTSR,
+    dokumenttype = Dokumenttype.FLYTTING_TSR_INTERNT_VEDTAK,
+    tittel = "Internt vedtak flytting",
+)
+
+@Component
+data object FlyttingTsrVedtaksbrevMetadata : VedtaksbrevMetadata(
+    tema = Tema.TSR,
+    behandlingstema = Behandlingstema.FlyttingTSR,
+    dokumenttype = Dokumenttype.FLYTTING_TSR_VEDTAKSBREV,
+)
+
+@Component
+data object FlyttingTsrKlageInterntVedtak : KlageInterntVedtak(
+    tema = Tema.TSR,
+    behandlingstema = Behandlingstema.FlyttingTSR,
+    dokumenttype = Dokumenttype.FLYTTING_TSR_KLAGE_INTERNT_VEDTAK,
+)
+
+@Component
+data object FlyttingTsrKlageVedtak : KlageVedtak(
+    tema = Tema.TSR,
+    behandlingstema = Behandlingstema.FlyttingTSR,
+    dokumenttype = Dokumenttype.FLYTTING_TSR_KLAGE_VEDTAKSBREV,
+)

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/metadata/MetadataReiseTilSamlingTSO.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/metadata/MetadataReiseTilSamlingTSO.kt
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component
 data object ReiseTilSamlingTsoSøknadMetadata : SøknadMetadata(
     tema = Tema.TSO,
     behandlingstema = Behandlingstema.ReiseTilSamlingTSO,
-    dokumenttype = Dokumenttype.REISE_TIL_SAMLING_SØKNAD,
+    dokumenttype = Dokumenttype.REISE_TIL_SAMLING_TSO_SØKNAD,
     tittel = "Søknad om ${
         Stønadstype.REISE_TIL_SAMLING_TSO.visningsnavn}",
     brevkode = DokumentBrevkode.REISE_TIL_SAMLING.verdi,
@@ -20,7 +20,7 @@ data object ReiseTilSamlingTsoSøknadMetadata : SøknadMetadata(
 @Component
 data object ReiseTilSamlingTsoSøknadVedleggMetadata : SøknadVedleggMetadata(
     tema = Tema.TSO,
-    dokumenttype = Dokumenttype.REISE_TIL_SAMLING_SØKNAD_VEDLEGG,
+    dokumenttype = Dokumenttype.REISE_TIL_SAMLING_TSO_SØKNAD_VEDLEGG,
 )
 
 @Component

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/metadata/MetadataReiseTilSamlingTSR.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/dokarkiv/metadata/MetadataReiseTilSamlingTSR.kt
@@ -1,0 +1,59 @@
+package no.nav.tilleggsstonader.integrasjoner.dokarkiv.metadata
+
+import no.nav.tilleggsstonader.kontrakter.dokarkiv.Dokumenttype
+import no.nav.tilleggsstonader.kontrakter.felles.Behandlingstema
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.kontrakter.felles.Tema
+import no.nav.tilleggsstonader.kontrakter.sak.DokumentBrevkode
+import org.springframework.stereotype.Component
+
+@Component
+data object ReiseTilSamlingTsrSøknadMetadata : SøknadMetadata(
+    tema = Tema.TSR,
+    behandlingstema = Behandlingstema.ReiseTilSamlingTSR,
+    dokumenttype = Dokumenttype.REISE_TIL_SAMLING_TSR_SØKNAD,
+    tittel = "Søknad om ${Stønadstype.REISE_TIL_SAMLING_TSR.visningsnavn}",
+    brevkode = DokumentBrevkode.REISE_TIL_SAMLING.verdi,
+)
+
+@Component
+data object ReiseTilSamlingTsrSøknadVedleggMetadata : SøknadVedleggMetadata(
+    tema = Tema.TSR,
+    dokumenttype = Dokumenttype.REISE_TIL_SAMLING_TSR_SØKNAD_VEDLEGG,
+)
+
+@Component
+data object ReiseTilSamlingTsrFrittståendeBrevMetadata : FrittståendeBrevMetadata(
+    tema = Tema.TSR,
+    behandlingstema = Behandlingstema.ReiseTilSamlingTSR,
+    dokumenttype = Dokumenttype.REISE_TIL_SAMLING_TSR_FRITTSTÅENDE_BREV,
+)
+
+@Component
+data object ReiseTilSamlingTsrInterntVedtakMetadata : InterntVedtakBrevMetadata(
+    tema = Tema.TSR,
+    behandlingstema = Behandlingstema.ReiseTilSamlingTSR,
+    dokumenttype = Dokumenttype.REISE_TIL_SAMLING_TSR_INTERNT_VEDTAK,
+    tittel = "Internt vedtak reise til samling",
+)
+
+@Component
+data object ReiseTilSamlingTsrVedtaksbrevMetadata : VedtaksbrevMetadata(
+    tema = Tema.TSR,
+    behandlingstema = Behandlingstema.ReiseTilSamlingTSR,
+    dokumenttype = Dokumenttype.REISE_TIL_SAMLING_TSR_VEDTAKSBREV,
+)
+
+@Component
+data object ReiseTilSamlingTsrKlageInterntVedtak : KlageInterntVedtak(
+    tema = Tema.TSR,
+    behandlingstema = Behandlingstema.ReiseTilSamlingTSR,
+    dokumenttype = Dokumenttype.REISE_TIL_SAMLING_TSR_KLAGE_INTERNT_VEDTAK,
+)
+
+@Component
+data object ReiseTilSamlingTsrKlageVedtak : KlageVedtak(
+    tema = Tema.TSR,
+    behandlingstema = Behandlingstema.ReiseTilSamlingTSR,
+    dokumenttype = Dokumenttype.REISE_TIL_SAMLING_TSR_KLAGE_VEDTAKSBREV,
+)


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Gjøre-jobb for å tilrettelegge for videre arbeid med flytting.

Temp-versjon av kontrakter, så bygg feiler før kontrakter er inne. Bygger mot https://github.com/navikt/tilleggsstonader-kontrakter/pull/202 (kompilerer om bygger kontrakter med `./gradlew -Pversion=1 publishToMavenLocal`)