### PR TITLE
Henter ut journalposter på fagsakId

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/journalpost/HentJournalpostController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/journalpost/HentJournalpostController.kt
@@ -91,6 +91,11 @@ class HentJournalpostController(
         @RequestBody journalposterForBrukerRequest: JournalposterForBrukerRequest,
     ): List<Journalpost> = journalpostService.finnJournalposter(journalposterForBrukerRequest)
 
+    @PostMapping("fagsak")
+    fun hentJournalposterForFagsak(
+        @RequestBody fagsakId: String,
+    ): List<Journalpost> = journalpostService.finnJournalposterForFagsak(fagsakId)
+
     @GetMapping("hentdokument/{journalpostId}/{dokumentInfoId}")
     fun hentDokument(
         @PathVariable journalpostId: String,

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/journalpost/JournalpostService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/journalpost/JournalpostService.kt
@@ -28,6 +28,8 @@ class JournalpostService
         fun finnJournalposter(journalposterForBrukerRequest: JournalposterForBrukerRequest): List<Journalpost> =
             safClient.finnJournalposter(journalposterForBrukerRequest)
 
+        fun finnJournalposterForFagsak(fagsakId: String): List<Journalpost> = safClient.finnJournalposterForFagsak(fagsakId)
+
         fun hentDokument(
             journalpostId: String,
             dokumentInfoId: String,

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/journalpost/client/SafClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/journalpost/client/SafClient.kt
@@ -4,13 +4,17 @@ import no.nav.tilleggsstonader.integrasjoner.journalpost.JournalpostForbiddenExc
 import no.nav.tilleggsstonader.integrasjoner.journalpost.JournalpostRequestException
 import no.nav.tilleggsstonader.integrasjoner.journalpost.JournalpostRestClientException
 import no.nav.tilleggsstonader.integrasjoner.journalpost.internal.SafErrorCode
+import no.nav.tilleggsstonader.integrasjoner.journalpost.internal.SafFagsakInput
+import no.nav.tilleggsstonader.integrasjoner.journalpost.internal.SafFagsakVariabler
 import no.nav.tilleggsstonader.integrasjoner.journalpost.internal.SafJournalpostBrukerData
 import no.nav.tilleggsstonader.integrasjoner.journalpost.internal.SafJournalpostData
+import no.nav.tilleggsstonader.integrasjoner.journalpost.internal.SafJournalpostFagsakData
 import no.nav.tilleggsstonader.integrasjoner.journalpost.internal.SafJournalpostRequest
 import no.nav.tilleggsstonader.integrasjoner.journalpost.internal.SafJournalpostResponse
 import no.nav.tilleggsstonader.integrasjoner.journalpost.internal.SafRequestVariabler
 import no.nav.tilleggsstonader.integrasjoner.util.MDCOperations
 import no.nav.tilleggsstonader.integrasjoner.util.graphqlQuery
+import no.nav.tilleggsstonader.kontrakter.felles.Fagsystem
 import no.nav.tilleggsstonader.kontrakter.journalpost.Journalpost
 import no.nav.tilleggsstonader.kontrakter.journalpost.JournalposterForBrukerRequest
 import no.nav.tilleggsstonader.libs.http.client.postForEntity
@@ -58,6 +62,48 @@ class SafClient(
                     "Kan ikke hente journalpost " + response.errors?.toString(),
                     null,
                     journalpostId,
+                )
+            }
+        }
+    }
+
+    fun finnJournalposterForFagsak(fagsakId: String): List<Journalpost> {
+        val safJournalpostRequest =
+            SafJournalpostRequest(
+                variables =
+                    SafFagsakVariabler(
+                        SafFagsakInput(
+                            fagsakId = fagsakId,
+                            fagsaksystem = Fagsystem.TILLEGGSSTONADER.navn,
+                        ),
+                    ),
+                query = graphqlQuery("/saf/journalposterForFagsak.graphql"),
+            )
+        val response =
+            restTemplate.postForEntity<SafJournalpostResponse<SafJournalpostFagsakData>>(
+                uri = safUri,
+                payload = safJournalpostRequest,
+                httpHeaders = httpHeaders(),
+            )
+
+        if (!response.harFeil()) {
+            return response.data?.dokumentoversiktFagsak?.journalposter
+                ?: throw JournalpostRequestException(
+                    message = "Kan ikke hente journalposter for fagsak",
+                    cause = null,
+                    safJournalpostRequest = safJournalpostRequest,
+                )
+        } else {
+            val tilgangFeil =
+                response.errors?.firstOrNull { it.message.contains("Tilgang til ressurs ble avvist") }
+
+            if (tilgangFeil != null) {
+                throw JournalpostForbiddenException(tilgangFeil.message)
+            } else {
+                throw JournalpostRequestException(
+                    message = "Kan ikke hente journalposter for fagsak " + response.errors?.toString(),
+                    cause = null,
+                    safJournalpostRequest = safJournalpostRequest,
                 )
             }
         }

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/journalpost/client/SafClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/journalpost/client/SafClient.kt
@@ -74,7 +74,7 @@ class SafClient(
                     SafFagsakVariabler(
                         SafFagsakInput(
                             fagsakId = fagsakId,
-                            fagsaksystem = Fagsystem.TILLEGGSSTONADER.navn,
+                            fagsaksystem = Fagsystem.TILLEGGSSTONADER.toString(),
                         ),
                     ),
                 query = graphqlQuery("/saf/journalposterForFagsak.graphql"),

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/journalpost/internal/SafJournalpostFagsakData.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/journalpost/internal/SafJournalpostFagsakData.kt
@@ -1,0 +1,5 @@
+package no.nav.tilleggsstonader.integrasjoner.journalpost.internal
+
+class SafJournalpostFagsakData(
+    val dokumentoversiktFagsak: Journalpostliste,
+)

--- a/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/journalpost/internal/SafJournalpostRequest.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/integrasjoner/journalpost/internal/SafJournalpostRequest.kt
@@ -8,3 +8,12 @@ data class SafJournalpostRequest(
     val variables: Any,
     val query: String,
 )
+
+data class SafFagsakVariabler(
+    val fagsak: SafFagsakInput,
+)
+
+data class SafFagsakInput(
+    val fagsakId: String,
+    val fagsaksystem: String,
+)

--- a/src/main/resources/saf/journalposterForFagsak.graphql
+++ b/src/main/resources/saf/journalposterForFagsak.graphql
@@ -1,0 +1,21 @@
+query journalposterForFagsak($fagsak: FagsakInput!) {
+    dokumentoversiktFagsak(fagsak: $fagsak) {
+        journalposter {
+            journalpostId
+            journalposttype
+            journalstatus
+            tema
+            tittel
+            behandlingstema
+            sak { arkivsaksystem arkivsaksnummer datoOpprettet fagsakId fagsaksystem }
+            bruker { id type }
+            avsenderMottaker { id type navn land erLikBruker }
+            journalforendeEnhet
+            kanal
+            utsendingsinfo { varselSendt { type, varslingstidspunkt }, fysiskpostSendt { adressetekstKonvolutt }, digitalpostSendt { adresse } }
+            dokumenter { dokumentInfoId tittel brevkode dokumentstatus dokumentvarianter { variantformat, saksbehandlerHarTilgang } logiskeVedlegg { logiskVedleggId tittel } }
+            relevanteDatoer { dato datotype }
+            eksternReferanseId
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/integrasjoner/journalpost/HentJournalpostControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/integrasjoner/journalpost/HentJournalpostControllerTest.kt
@@ -61,6 +61,25 @@ class HentJournalpostControllerTest : IntegrationTest() {
     }
 
     @Test
+    fun `hent journalposterForFagsak skal returnere journalposter og status ok`() {
+        stubGraphqlEndpoint("saf/gyldigJournalposterForFagsakResponse.json")
+        val fagsakId = "12345"
+
+        val response =
+            restTemplate.exchange<List<Journalpost>>(
+                localhost(JOURNALPOST_BASE_URL) + "/fagsak",
+                HttpMethod.POST,
+                HttpEntity(fagsakId, headers),
+            )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body).hasSize(1)
+        assertThat(response.body?.first()?.journalpostId).isEqualTo("453492634")
+        assertThat(response.body?.first()?.journalposttype).isEqualTo(Journalposttype.I)
+        assertThat(response.body?.first()?.journalstatus).isEqualTo(Journalstatus.JOURNALFOERT)
+    }
+
+    @Test
     fun `hent saksnummer skal returnere saksnummer og status ok`() {
         stubGraphqlEndpoint("saf/gyldigsakresponse.json", expectedRequestBody = gyldigJournalPostIdRequest())
 

--- a/src/test/resources/saf/gyldigJournalposterForFagsakResponse.json
+++ b/src/test/resources/saf/gyldigJournalposterForFagsakResponse.json
@@ -1,0 +1,55 @@
+{
+  "data": {
+    "dokumentoversiktFagsak": {
+      "journalposter": [
+        {
+          "journalpostId": "453492634",
+          "journalposttype": "I",
+          "journalstatus": "JOURNALFOERT",
+          "tema": "TSO",
+          "tittel": "Søknad om tilleggsstønad",
+          "behandlingstema": null,
+          "sak": {
+            "arkivsaksystem": "GSAK",
+            "arkivsaksnummer": "140259389",
+            "datoOpprettet": "2024-01-15T10:00:00",
+            "fagsakId": "12345",
+            "fagsaksystem": "TILLEGGSSTONADER"
+          },
+          "bruker": {
+            "id": "2557381234833",
+            "type": "AKTOERID"
+          },
+          "journalforendeEnhet": "4462",
+          "kanal": "NAV_NO",
+          "utsendingsinfo": null,
+          "dokumenter": [
+            {
+              "dokumentInfoId": "453871494",
+              "tittel": "Søknad om tilleggsstønad",
+              "brevkode": "NAV 15-00.01",
+              "dokumentstatus": null,
+              "dokumentvarianter": [
+                {
+                  "variantformat": "ARKIV",
+                  "saksbehandlerHarTilgang": true
+                }
+              ],
+              "logiskeVedlegg": []
+            }
+          ],
+          "relevanteDatoer": [
+            {
+              "dato": "2024-01-15T10:00:00",
+              "datotype": "DATO_DOKUMENT"
+            },
+            {
+              "dato": "2024-01-15T10:05:00",
+              "datotype": "DATO_JOURNALFOERT"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Gjør dette for å kun vise journalposter tilknyttet en fagsak. Da slipper man å se dokumenter for læremidler inne på en daglig reise